### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
 	// for the documentation about the extensions.json format
 	"recommendations": [
 		// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-		"ms-vscode.csharp",
+		"ms-dotnettools.csharp",
 		"quantum.quantum-devkit-vscode"
 	]
 }


### PR DESCRIPTION
Saw that you currently don't accept contributions so feel free to close this one.
But the C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp", this means all extensions depending on it needs to be updated and all repositories with extension.json containing
```json
"recommendations": [
    "ms-vscode.csharp"
 ]
```
or you get errors like

![image](https://user-images.githubusercontent.com/1647294/76144809-2c18e500-6084-11ea-80ab-f365de742c99.png)
