### PR TITLE
Update Quantum SDK references to enable local e2e builds after compiler breaking change

### DIFF
--- a/samples/characterization/random-walk-pe/random-walk-pe.csproj
+++ b/samples/characterization/random-walk-pe/random-walk-pe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.11.2003.3107">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,7 +12,7 @@
              When writing your own code to use the Microsoft.Quantum.Research
              package, we recommend using the following instead:
 
-                <PackageReference Include="Microsoft.Quantum.Research" Version="0.11.2003.3107" />
+                <PackageReference Include="Microsoft.Quantum.Research" Version="0.13.20111102-beta" />
     -->
     <ProjectReference Include="../../../src/research/research.csproj" />
   </ItemGroup>

--- a/samples/simulation/qsp/qsp.csproj
+++ b/samples/simulation/qsp/qsp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.11.2003.3107">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,7 +12,7 @@
              When writing your own code to use the Microsoft.Quantum.Research
              package, we recommend using the following instead:
 
-                <PackageReference Include="Microsoft.Quantum.Research" Version="0.11.2003.3107" />
+                <PackageReference Include="Microsoft.Quantum.Research" Version="0.13.20111102-beta" />
     -->
     <ProjectReference Include="../../../src/research/research.csproj" />
   </ItemGroup>

--- a/src/characterization/characterization.csproj
+++ b/src/characterization/characterization.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.11.2003.3107">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/chemistry/chemistry.csproj
+++ b/src/chemistry/chemistry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.11.2003.3107">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.20111102-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/main/Tests.Research.csproj
+++ b/src/tests/main/Tests.Research.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2003.3107">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.13.20111102-beta">
   
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.11.2003.3107" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.11.2003.3107" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.13.20111102-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.20111102-beta" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>


### PR DESCRIPTION
This change updates references to the Quantum SDK such to make them compatible with the latest version of the compiler and enable local e2e builds.