### PR TITLE
Revert "Update NuGet.Config (#54)"

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -15,8 +15,6 @@
 -->
 <configuration>
   <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="qdk-alpha" value="https://pkgs.dev.azure.com/ms-quantum-public/Microsoft Quantum (public)/_packaging/alpha/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Revert NuGet.config change as it introduced a break into end to end builds that wasn't caught by PR validations.