### PR TITLE
Update QDK to .NET6.0 (Quantum-NC)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,4 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+build/267DevDivSNKey2048.snk

--- a/build/set-env.ps1
+++ b/build/set-env.ps1
@@ -19,3 +19,6 @@ If (-not (Test-Path -Path $Env:NUGET_OUTDIR)) { [IO.Directory]::CreateDirectory(
 If ($Env:DOCS_OUTDIR -eq $null) { $Env:DOCS_OUTDIR =  (Join-Path $Env:DROPS_DIR "docs") }
 If (-not (Test-Path -Path $Env:DOCS_OUTDIR)) { [IO.Directory]::CreateDirectory($Env:DOCS_OUTDIR) }
 
+If ($Env:LOGS_OUTDIR -eq $null) { $Env:LOGS_OUTDIR =  (Join-Path $Env:DROPS_DIR "logs") }
+If (-not (Test-Path -Path $Env:LOGS_OUTDIR)) { [IO.Directory]::CreateDirectory($Env:LOGS_OUTDIR) }
+

--- a/build/steps.yml
+++ b/build/steps.yml
@@ -1,10 +1,10 @@
 steps:
 
 - task: UseDotNet@2
-  displayName: 'Use .NET Core SDK 3.1.100'
+  displayName: 'Use .NET Core SDK 6.0'
   inputs:
     packageType: sdk
-    version: '3.1.100'
+    version: '6.0.x'
 
 
 - powershell: ./build.ps1

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -9,7 +9,7 @@ $all_ok = $True
 function Test-One {
     Param($project)
 
-    $TestsLogs = Join-Path $Env:LOGS_OUTDIR log-tests-quantum-nc.tt
+    $TestsLogs = Join-Path $Env:LOGS_OUTDIR log-tests-quantum-nc.txt
 
     dotnet test (Join-Path $PSScriptRoot $project) --diag:"$TestsLogs" `
         -c $Env:BUILD_CONFIGURATION `

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -9,7 +9,9 @@ $all_ok = $True
 function Test-One {
     Param($project)
 
-    dotnet test (Join-Path $PSScriptRoot $project) `
+    $TestsLogs = Join-Path $Env:LOGS_OUTDIR log-tests-quantum-nc.tt
+
+    dotnet test (Join-Path $PSScriptRoot $project) --diag:"$TestsLogs" `
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
         --logger trx `

--- a/samples/characterization/random-walk-pe/random-walk-pe.csproj
+++ b/samples/characterization/random-walk-pe/random-walk-pe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112179912-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -13,7 +13,7 @@
              When writing your own code to use the Microsoft.Quantum.Research
              package, we recommend using the following instead:
 
-                <PackageReference Include="Microsoft.Quantum.Research" Version="0.21.2112179912-beta" />
+                <PackageReference Include="Microsoft.Quantum.Research" Version="0.21.2112181770-beta" />
     -->
     <ProjectReference Include="../../../src/research/research.csproj" />
   </ItemGroup>

--- a/samples/characterization/random-walk-pe/random-walk-pe.csproj
+++ b/samples/characterization/random-walk-pe/random-walk-pe.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <QSharpDocsGeneration>false</QSharpDocsGeneration>
   </PropertyGroup>
 

--- a/samples/characterization/random-walk-pe/random-walk-pe.csproj
+++ b/samples/characterization/random-walk-pe/random-walk-pe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140472">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112179912-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -13,7 +13,7 @@
              When writing your own code to use the Microsoft.Quantum.Research
              package, we recommend using the following instead:
 
-                <PackageReference Include="Microsoft.Quantum.Research" Version="0.16.2105140472" />
+                <PackageReference Include="Microsoft.Quantum.Research" Version="0.21.2112179912-beta" />
     -->
     <ProjectReference Include="../../../src/research/research.csproj" />
   </ItemGroup>

--- a/samples/characterization/random-walk-pe/random-walk-pe.csproj
+++ b/samples/characterization/random-walk-pe/random-walk-pe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112182074-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -13,7 +13,7 @@
              When writing your own code to use the Microsoft.Quantum.Research
              package, we recommend using the following instead:
 
-                <PackageReference Include="Microsoft.Quantum.Research" Version="0.21.2112181770-beta" />
+                <PackageReference Include="Microsoft.Quantum.Research" Version="0.21.2112182074-beta" />
     -->
     <ProjectReference Include="../../../src/research/research.csproj" />
   </ItemGroup>

--- a/samples/simulation/qsp/qsp.csproj
+++ b/samples/simulation/qsp/qsp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112179912-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -13,7 +13,7 @@
              When writing your own code to use the Microsoft.Quantum.Research
              package, we recommend using the following instead:
 
-                <PackageReference Include="Microsoft.Quantum.Research" Version="0.21.2112179912-beta" />
+                <PackageReference Include="Microsoft.Quantum.Research" Version="0.21.2112181770-beta" />
     -->
     <ProjectReference Include="../../../src/research/research.csproj" />
   </ItemGroup>

--- a/samples/simulation/qsp/qsp.csproj
+++ b/samples/simulation/qsp/qsp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <QSharpDocsGeneration>false</QSharpDocsGeneration>
   </PropertyGroup>
 

--- a/samples/simulation/qsp/qsp.csproj
+++ b/samples/simulation/qsp/qsp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140472">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112179912-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -13,7 +13,7 @@
              When writing your own code to use the Microsoft.Quantum.Research
              package, we recommend using the following instead:
 
-                <PackageReference Include="Microsoft.Quantum.Research" Version="0.16.2105140472" />
+                <PackageReference Include="Microsoft.Quantum.Research" Version="0.21.2112179912-beta" />
     -->
     <ProjectReference Include="../../../src/research/research.csproj" />
   </ItemGroup>

--- a/samples/simulation/qsp/qsp.csproj
+++ b/samples/simulation/qsp/qsp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112182074-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -13,7 +13,7 @@
              When writing your own code to use the Microsoft.Quantum.Research
              package, we recommend using the following instead:
 
-                <PackageReference Include="Microsoft.Quantum.Research" Version="0.21.2112181770-beta" />
+                <PackageReference Include="Microsoft.Quantum.Research" Version="0.21.2112182074-beta" />
     -->
     <ProjectReference Include="../../../src/research/research.csproj" />
   </ItemGroup>

--- a/src/characterization/characterization.csproj
+++ b/src/characterization/characterization.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112182074-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/characterization/characterization.csproj
+++ b/src/characterization/characterization.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112179912-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/characterization/characterization.csproj
+++ b/src/characterization/characterization.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140472">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112179912-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/chemistry/chemistry.csproj
+++ b/src/chemistry/chemistry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140472">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112179912-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.16.2105140472" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.21.2112179912-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/chemistry/chemistry.csproj
+++ b/src/chemistry/chemistry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112182074-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.21.2112181770-beta" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.21.2112182074-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/chemistry/chemistry.csproj
+++ b/src/chemistry/chemistry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112179912-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.21.2112179912-beta" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.21.2112181770-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/main/Tests.Research.csproj
+++ b/src/tests/main/Tests.Research.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140472">
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <QSharpDocsGeneration>false</QSharpDocsGeneration>
   </PropertyGroup>

--- a/src/tests/main/Tests.Research.csproj
+++ b/src/tests/main/Tests.Research.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112182074-beta">
   
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.21.2112181770-beta" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.21.2112181770-beta" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.21.2112182074-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.21.2112182074-beta" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>

--- a/src/tests/main/Tests.Research.csproj
+++ b/src/tests/main/Tests.Research.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.16.2105140472">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112179912-beta">
   
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.16.2105140472" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.16.2105140472" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.21.2112179912-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.21.2112179912-beta" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>

--- a/src/tests/main/Tests.Research.csproj
+++ b/src/tests/main/Tests.Research.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112179912-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
   
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.21.2112179912-beta" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.21.2112179912-beta" />
+    <PackageReference Include="Microsoft.Quantum.Chemistry" Version="0.21.2112181770-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.21.2112181770-beta" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>

--- a/src/tests/qsp/Tests.QSP.fsproj
+++ b/src/tests/qsp/Tests.QSP.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <QSharpDocsGeneration>false</QSharpDocsGeneration>
   </PropertyGroup>
 


### PR DESCRIPTION
We're migrating the QDK to the most recent Long Time Support version of the .NET framework. For details about this change, refer to the original issue [Q#C:1224](https://github.com/microsoft/qsharp-compiler/issues/1224).

As part of this change, we're:

- Re-targeting all .NetCoreApp3.1 binaries to .NET6.0
- Updating Docker images, samples and templates.
- Libraries using .NetStandard2.1 are not affected by this change.
- The minimum supported .NET version in the QDK will also be updated from 3.1 to 6.0

This is a multi-repo change, and all changes will need to be merged concurrently.