### PR TITLE
Add global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,9 @@
+{
+    "sdk": {
+        "version": "6.0.100",
+        "rollForward": "latestMinor"
+    },
+    "msbuild-sdks": {
+        "Microsoft.Quantum.Sdk": "0.24.210051-beta"
+    }
+}


### PR DESCRIPTION
Changes on .Net 6.0.300 requires that a local global.json includes the version of the Quantum.Sdk otherwise projects that don't have it specified fail compilation, even if there is another global.json in their parent path.