### PR TITLE
Block set-env.ps1 from sending to output stream

### DIFF
--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -15,7 +15,7 @@ param(
 );
 
 
-& "$PSScriptRoot/set-env.ps1"
+& "$PSScriptRoot/set-env.ps1" | Out-Null
 
 $artifacts = @{
     Packages = @(


### PR DESCRIPTION
The end to end build takes the return from `manifest.ps1` by checking the output stream for `$artifacts`, which is [written to output](https://github.com/microsoft/Quantum-NC/blob/d8ff065ee7182e20b0a7c8ea1ac6eb6f8d342dd5/build/manifest.ps1#L39) at the end of the script. The `set-env.ps1` script is also writing to the output stream however, which prevents the end to end build from picking up the expected results. Piping the output from `set-env.ps1` to null ensures that the end to end build can pick up the expected output.