### PR TITLE
Fixing the undesirable dependencies issue for qdk

### DIFF
--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -27,7 +27,7 @@ $artifacts = @{
     Assemblies = @(
         ".\src\characterization\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Research.Characterization.dll",
         ".\src\chemistry\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Research.Chemistry.dll",
-        ".\src\simulation\qsp\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Research.Simulation.Qsp.dll"
+        ".\src\simulation\qsp\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Research.Simulation.Qsp.dll"
     ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };
 }
 

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -25,8 +25,8 @@ $artifacts = @{
     ) | ForEach-Object { Join-Path $Env:NUGET_OUTDIR "$_.$Env:NUGET_VERSION.nupkg" };
 
     Assemblies = @(
-        ".\src\characterization\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Research.Characterization.dll",
-        ".\src\chemistry\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Research.Chemistry.dll",
+        ".\src\characterization\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Research.Characterization.dll",
+        ".\src\chemistry\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Research.Chemistry.dll",
         ".\src\simulation\qsp\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Research.Simulation.Qsp.dll"
     ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };
 }

--- a/src/characterization/characterization.csproj
+++ b/src/characterization/characterization.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.27.253010">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Research.Characterization</AssemblyName>
     <QsharpDocsGeneration>true</QsharpDocsGeneration>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/chemistry/chemistry.csproj
+++ b/src/chemistry/chemistry.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.27.253010">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Research.Chemistry</AssemblyName>
     <QsharpDocsGeneration>true</QsharpDocsGeneration>  
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/research/research.csproj
+++ b/src/research/research.csproj
@@ -10,7 +10,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Research</AssemblyName>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/simulation/qsp/QuantumSignalProcessing.fsproj
+++ b/src/simulation/qsp/QuantumSignalProcessing.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Research.Simulation.Qsp</AssemblyName>
   </PropertyGroup>
 


### PR DESCRIPTION
DevOps 48463, 48471.
The `netstandard2.1` target framework has undesirable dependencies, migrating the affected packages to `net6.0`.

Multi-repo PR:
[Q#Compiler](https://github.com/microsoft/qsharp-compiler/pull/1601), [Q#RT](https://github.com/microsoft/qsharp-runtime/pull/1121), [iQ#](https://github.com/microsoft/iqsharp/pull/760), [QuantumLibraries](https://github.com/microsoft/QuantumLibraries/pull/656), [Quantum-NC](https://github.com/microsoft/Quantum-NC/pull/84), [Quantum](https://github.com/microsoft/Quantum/pull/771) (samples), [Katas](https://github.com/microsoft/QuantumKatas/pull/868), QDK, and a private repo.

PR CI build can fail, but overall qdk.release (0.27.254480) has succeeded.